### PR TITLE
Fix save session logic

### DIFF
--- a/app/src/core/session_db_postgres.py
+++ b/app/src/core/session_db_postgres.py
@@ -10,13 +10,30 @@ logging.getLogger(__name__)
 
 def get_conn():
     # Connection info from environment variables (fail early if not set)
-    return psycopg2.connect(
-        dbname=os.environ["DB_NAME"],
-        user=os.environ["DB_USER"],
-        password=os.environ["DB_PASSWORD"], 
-        host=os.environ["DB_HOST"],
-        port=os.environ["DB_PORT"]
-    )
+    try:
+        dbname = os.environ["DB_NAME"]
+        user = os.environ["DB_USER"]
+        password = os.environ["DB_PASSWORD"]
+        host = os.environ["DB_HOST"]
+        port = os.environ["DB_PORT"]
+        # Print first letter of non-secret values for debugging (never print password)
+        print(f"DB_NAME starts with: {dbname[:1]}")
+        print(f"DB_USER starts with: {user[:1]}")
+        print(f"DB_HOST starts with: {host[:1]}")
+        print(f"DB_PORT starts with: {port[:1]}")
+        return psycopg2.connect(
+            dbname=dbname,
+            user=user,
+            password=password, 
+            host=host,
+            port=port
+        )
+    except KeyError as e:
+        print(f"Missing required environment variable: {e}")
+        raise
+    except Exception as e:
+        print(f"Error connecting to PostgreSQL: {e}")
+        raise
 
 def ensure_sessions_table():
     conn = get_conn()

--- a/app/src/core/session_db_postgres.py
+++ b/app/src/core/session_db_postgres.py
@@ -11,16 +11,16 @@ logging.getLogger(__name__)
 def get_conn():
     # Connection info from environment variables (fail early if not set)
     try:
+        host = os.getenv("DB_HOST", "postgres.dev.tlt.harvard.edu")
+        port = int(os.getenv("DB_PORT", 5432))
         dbname = os.environ["DB_NAME"]
         user = os.environ["DB_USER"]
         password = os.environ["DB_PASSWORD"]
-        host = os.environ["DB_HOST"]
-        port = os.environ["DB_PORT"]
         # Print first letter of non-secret values for debugging (never print password)
-        print(f"DB_NAME starts with: {dbname[:1]}")
-        print(f"DB_USER starts with: {user[:1]}")
-        print(f"DB_HOST starts with: {host[:1]}")
-        print(f"DB_PORT starts with: {port[:1]}")
+        logging.debug(f"DB_NAME starts with: {dbname[:1]}")
+        logging.debug(f"DB_USER starts with: {user[:1]}")
+        logging.debug(f"DB_HOST starts with: {host}")
+        logging.debug(f"DB_PORT starts with: {port}")
         return psycopg2.connect(
             dbname=dbname,
             user=user,
@@ -29,10 +29,10 @@ def get_conn():
             port=port
         )
     except KeyError as e:
-        print(f"Missing required environment variable: {e}")
+        logging.error(f"Missing required environment variable: {e}")
         raise
     except Exception as e:
-        print(f"Error connecting to PostgreSQL: {e}")
+        logging.error(f"Error connecting to PostgreSQL: {e}")
         raise
 
 def ensure_sessions_table():

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,7 +9,7 @@ services:
       - ./:/app
     environment:
       - SESSION_DB_BACKEND=${SESSION_DB_BACKEND}
-      - WAIT_FOR_POSTGRES="true"
+      - WAIT_FOR_POSTGRES=true
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./app:/app
     environment:
       - SESSION_DB_BACKEND=${SESSION_DB_BACKEND}
-      - WAIT_FOR_POSTGRES="false
+      - WAIT_FOR_POSTGRES="false"
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./app:/app
     environment:
       - SESSION_DB_BACKEND=${SESSION_DB_BACKEND}
-      - WAIT_FOR_POSTGRES="false"
+      - WAIT_FOR_POSTGRES=false
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}


### PR DESCRIPTION
# Overview
improved session data storage, noticed there was only a single session in the RDS instance, fixed save_session logic to remove identifying session by name and default end_reason to not_captured

# Changes
- removed checking for session by name
- created default end_reason of "not captured"
- fix to WRITE_TO_PROGRES flag captured here and debug statements for db connection

